### PR TITLE
Add support for translation parameters.

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -165,7 +165,8 @@ function launchInteractiveTranslationPrompt (askKey) {
         key: key,
         where: str.where,
         indexInFile: str.indexInFile,
-        stringLength: str.stringLength
+        stringLength: str.stringLength,
+        expressions: str.expressions
       })
 
       if (askKey) {
@@ -179,7 +180,7 @@ function launchInteractiveTranslationPrompt (askKey) {
       manager.getLanguages().map((lang) => {
         questions.push({
           type: 'input',
-          message: `[${lang}] Translation for "${str.string}"`,
+          message: `[${lang}] Translation for "${str.originalString}"`,
           name: `${replaceAll(key, '.', '/')}.${lang}`,
           default: str.string
         })

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -33,6 +33,23 @@ string to translate. If you are content with the default string then just hit `e
 also enter a complete new key, separated by dots, or just enter a single word. Then it will
 just replace the last part of the suggested key.
 
+This tool will also find translations separated with interpolated strings. It will convert these
+dynamic data to be passed to translation as parameters. Interpolated strings will be available 
+in translation under `param[$i]` variable.
+
+Here is an example:
+``` vue
+<p>Hello {{ user.name }}</p>
+```
+
+That will result in following transformation:
+``` vue
+<p>{{ $t('hello', { param0: user.name }) }}
+```
+
+You can reference this variable in translation like this: `'Hello {param0}'`. Feel free to 
+rename these variables later for more readable code.
+
 ## `clean`
 
 This command looks at all the translations in your configured translation files and searches

--- a/index.js
+++ b/index.js
@@ -72,16 +72,53 @@ TranslationManager.prototype.getStringsForComponent = function (pathToComponent)
   var templateOffset = templateResult.offset
   var template = templateResult.template
 
-  var matches = execall(/>([^<>{}]*)</gm, template)
+  var matches = execall(/>([^<>]*)</gm, template)
+
+  function extractTemplateExpression (text) {
+    const indexOfOpening = text.indexOf('{{')
+    const indexOfClosing = text.indexOf('}}')
+    if (indexOfClosing === -1 || indexOfOpening === -1) {
+      return {
+        expression: null,
+        text: text
+      }
+    }
+    return {
+      expression: text.substring(indexOfOpening + 2, indexOfClosing).trim(),
+      text: '' + text.substring(0, indexOfOpening) + text.substring(indexOfClosing + 2)
+    }
+  }
+
+  function checkTemplateExpression (text) {
+    let currText = text
+    let expression = true
+    const expressions = []
+    while (expression !== null) {
+      const result = extractTemplateExpression(currText)
+      currText = result.text
+      expression = result.expression
+      if (expression !== null) {
+        expressions.push(expression)
+      }
+    }
+    return {
+      staticText: currText.trim(),
+      hasStaticText: currText.trim().length > 0,
+      expressions
+    }
+  }
 
   var textNodeMatches = matches.map((match) => {
-    if (match.sub[0].trim() === '' || match.sub[0].trim().length < 3) return
-
+    const expressionsInfo = checkTemplateExpression(match.sub[0])
+    if (!expressionsInfo.hasStaticText) return
+    if (expressionsInfo.staticText.length < 3) return
     return {
       indexInTemplate: match.index + 1,
       indexInFile: templateOffset + match.index + 1,
-      string: match.sub[0].trim(),
+      originalString: match.sub[0],
+      string: expressionsInfo.staticText,
       stringLength: match.sub[0].length,
+      expressions: expressionsInfo.expressions,
       where: 'textNode'
     }
   }).filter(Boolean)
@@ -94,8 +131,10 @@ TranslationManager.prototype.getStringsForComponent = function (pathToComponent)
     return {
       indexInTemplate: match.index + match.match.indexOf(match.sub[2]),
       indexInFile: templateOffset + match.index + match.match.indexOf(match.sub[2]),
+      originalString: match.sub[2].trim(),
       string: match.sub[2].trim(),
       stringLength: match.sub[2].length,
+      expressions: [],
       where: 'attribute'
     }
   }).filter(Boolean)
@@ -115,10 +154,16 @@ TranslationManager.prototype.getStringsForComponent = function (pathToComponent)
 TranslationManager.prototype.replaceStringsInComponent = function (pathToComponent, strings) {
   var fileContents = fs.readFileSync(pathToComponent, { encoding: 'utf8' })
   var contentsAfter = fileContents
-
   var offset = 0
   strings.map((str) => {
     var translateFn = `{{ $t('${str.key}') }}`
+    if (str.expressions.length > 0) {
+      var params = []
+      for (var i = 0; i < str.expressions.length; i++) {
+        params.push(`param${i}: ${str.expressions[i]}`)
+      }
+      translateFn = `{{ $t('${str.key}', { ${params.join(', ')} }) }}`
+    }
     var firstPart = contentsAfter.substring(0, offset + str.indexInFile)
     var secondPart = contentsAfter.substring(offset + str.indexInFile + str.stringLength)
 

--- a/test/data/test-1/src/components/Test.vue
+++ b/test/data/test-1/src/components/Test.vue
@@ -5,6 +5,8 @@
       <li v-for="user in users" :key="user.id">
         <b>Name: </b> {{user.name}}<br>
         <b>Birthday: </b> {{user.birthday}}<br>
+        <b>Hello text: {{ user.male ? 'Mr' : 'Mrs' }} {{ user.name }}</b><br>
+        <b>{{ user.name }} Birthday: {{ user.birthday}}</b><br>
       </li>
     </ul>
   </div>

--- a/test/test-index.js
+++ b/test/test-index.js
@@ -84,7 +84,7 @@ test('getStringsForComponent', function (t) {
   var pathToFile = path.join(__dirname, 'data/test-1/src/components/Test.vue')
   var strings = m.getStringsForComponent(pathToFile)
   t.ok(strings, 'there is a result')
-  t.equal(strings.length, 3, 'there are three strings in the file')
+  t.equal(strings.length, 5, 'there are five strings in the file')
   t.equal(strings[0].indexInTemplate, 17, 'indexInTemplate is correct')
   t.equal(strings[0].indexInFile, 27, 'indexInFile is correct')
   t.ok(strings[0].string, 'string is given')


### PR DESCRIPTION
Added support for parameters in translations.
Unfortunately, solution presented in issue could not be done. There is a problem with naming parameters. User could provide in each language different names and that cannot be resolved automatically. So I decided just to names these params automatically: `param[$i]`. With this we always provide every interpolated data to be used in translation and user can later rename them in template file to his needs.

Should close #4 