### PR TITLE
Use the 'camelCase' method from Lodash. Double spaces crash fix.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const path = require('path')
 const execall = require('execall')
 const glob = require('glob')
 const uniq = require('lodash.uniq')
+const camelCase = require('lodash.camelCase')
 
 /**
  * Initialize the translation manager
@@ -321,20 +322,6 @@ TranslationManager.prototype.validate = async function () {
     }
   })
   return missingKeys
-}
-
-/**
- * camelCase any string
- * @param {string} text The string to be camelCased
- * @returns {string} theStringInCamelCase
- */
-function camelCase (text) {
-  return text
-    .trim()
-    .split(' ')
-    .map((word) => word.toLowerCase())
-    .map((word, i) => (i === 0 ? word : word[0].toUpperCase() + word.substring(1)))
-    .join('')
 }
 
 function increaseTrailingNumber (str) {


### PR DESCRIPTION
This little pull request fixes a crash when `getSuggestedKey` tries to parse a text with double spaces.

```
UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'toUpperCase' of undefined
    at /... .../node_modules/vue-translation-manager/index.js:338:49
```